### PR TITLE
为 AdGuard Home for Magisk 添加秋风广告规则

### DIFF
--- a/AdGuardHome.yaml
+++ b/AdGuardHome.yaml
@@ -100,9 +100,13 @@ statistics:
   enabled: true
 filters:
   - enabled: true
-    url: https://anti-ad.net/easylist.txt
-    name: 'CHN: anti-AD'
-    id: 1640156838
+    url: https://github.tmby.shop/https://raw.githubusercontent.com/TG-Twilight/AWAvenue-Ads-Rule/main/AWAvenue-Ads-Rule.txt
+    name: '秋风广告规则(AWAvenue-Ads-Rule_天命CFCDN订阅源)'
+    id: 1699370433972
+#  - enabled: true
+#    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_53.txt
+#    name: '秋风广告规则(AWAvenue-Ads-Rule_AdGuardTeam官方订阅源)'
+#    id: 1699370433972
 whitelist_filters: []
 user_rules:
   - ""

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# 此仓库为秋风广告规则为AdGuard Home for Magisk添加秋风广告规则之仓库，如果您需要订阅 秋风广告规则(AWAvenue Ads Rule)请前往我们的[官方仓库](https://github.com/TG-Twilight/AWAvenue-Ads-Rule)进行订阅！
+
 # AdGuardHome_magisk
 这是一个让AdGuardHome运行在安卓设备上的去广告magisk模块。
 


### PR DESCRIPTION
为 AdGuard Home for Magisk 添加秋风广告规则，并移除anti ad（经长期的用户反馈，误杀严重）。

首先简单介绍一下：[秋风广告规则(AWAvenue Ads Rule)](https://github.com/TG-Twilight/AWAvenue-Ads-Rule)是一款主要为 Android 设备提供广告拦截的规则，相较于其它动辄成千上万条的广告规则相比，秋风广告规则有着超高的命中率、极致的体积控制和极低的硬件要求。

更多的信息可以查看我们的[官方网站](awavenue.top)

经过实际测试，我们可以成功拦截提瓦特大陆绝大多数的广告sdk（的广告资源获取）。


经过长期的考察与用户反馈，我们发现有许多订阅用户都在使用贵项目的 Magisk 模块，并且贵项目目前的维护也相对比较积极，所以我们希望直接将我们的广告规则添加进默认模板中，来为用户提供更好更方便的无广告浏览体验。